### PR TITLE
Fix appsettings.json syntax

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -1,4 +1,3 @@
-{
     {
         "ConnectionStrings": {
             "DefaultConnection": "Server=localhost;Database=LMSDb;Trusted_Connection=True;"


### PR DESCRIPTION
## Summary
- remove stray opening brace from appsettings.json
- ensure file parses as valid JSON

## Testing
- `jq empty appsettings.json`

------
https://chatgpt.com/codex/tasks/task_e_685b8a0d667c832fb3b4acacae8731eb