### PR TITLE
Fix csproj compile settings

### DIFF
--- a/Tests/LSM.Tests.csproj
+++ b/Tests/LSM.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
@@ -12,6 +13,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="obj\**\*.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Controllers\**\*.cs" />


### PR DESCRIPTION
## Summary
- tweak LSM.Tests.csproj compile settings

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c2c48f9f8832f97683ea5030ac914