### PR TITLE
Add assignment management endpoint

### DIFF
--- a/Controllers/AssignmentsController.cs
+++ b/Controllers/AssignmentsController.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using LMSApp.Data;
+using LMSApp.Models;
+using LMSApp.DTOs;
+
+namespace LMSApp.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AssignmentsController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+
+        public AssignmentsController(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateAssignmentDto dto)
+        {
+            var course = await _context.Courses.FindAsync(dto.CourseId);
+            if (course == null)
+                return NotFound("Course not found.");
+
+            var assignment = new Assignment
+            {
+                Title = dto.Title,
+                Description = dto.Description,
+                DueDate = dto.DueDate,
+                CourseId = dto.CourseId
+            };
+
+            _context.Assignments.Add(assignment);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction(nameof(GetById), new { id = assignment.Id }, assignment);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(int id)
+        {
+            var assignment = await _context.Assignments
+                .Include(a => a.Course)
+                .FirstOrDefaultAsync(a => a.Id == id);
+
+            if (assignment == null)
+                return NotFound();
+
+            return Ok(assignment);
+        }
+
+        [HttpGet("course/{courseId}")]
+        public async Task<IActionResult> GetForCourse(int courseId)
+        {
+            var assignments = await _context.Assignments
+                .Where(a => a.CourseId == courseId)
+                .ToListAsync();
+
+            return Ok(assignments);
+        }
+    }
+}

--- a/DTOs/CreateAssignmentDto.cs
+++ b/DTOs/CreateAssignmentDto.cs
@@ -1,0 +1,7 @@
+public class CreateAssignmentDto
+{
+    public string Title { get; set; } = "";
+    public string Description { get; set; } = "";
+    public DateTime DueDate { get; set; }
+    public int CourseId { get; set; }
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Key Features:
 - Create and join courses or study groups
 - Upload and download course materials
 - Shared notes with group members
+- Manage course assignments
 - Task and deadline reminders through email
 Software Requirements:
 Functional:

--- a/Tests/AssignmentTests.cs
+++ b/Tests/AssignmentTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+public class AssignmentTests
+{
+    private AppDbContext GetContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task Create_AddsAssignmentToDatabase()
+    {
+        using var context = GetContext();
+        context.Courses.Add(new Course
+        {
+            Id = 1,
+            Title = "Test Course",
+            Description = "Desc",
+            InstructorId = 1,
+            Instructor = new User
+            {
+                FullName = "Instr",
+                Email = "i@example.com",
+                PasswordHash = "hash",
+                Role = "Instructor"
+            }
+        });
+        await context.SaveChangesAsync();
+        var controller = new LMSApp.Controllers.AssignmentsController(context);
+        var dto = new CreateAssignmentDto
+        {
+            Title = "Assign 1",
+            Description = "Desc",
+            DueDate = DateTime.UtcNow,
+            CourseId = 1
+        };
+
+        var result = await controller.Create(dto);
+        var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+        var assignment = Assert.IsType<Assignment>(createdResult.Value);
+        Assert.Equal(1, assignment.CourseId);
+        Assert.Equal(1, await context.Assignments.CountAsync());
+    }
+}


### PR DESCRIPTION
## Summary
- manage course assignments with a new controller
- add a DTO for creating assignments
- cover assignment creation with unit tests
- mention assignment management in README

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c52f077f4832f94dd983e1d580795